### PR TITLE
set both .github-ci versions to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source-code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup (Nixpkgs config and NIXPKGS_COMMIT)
         run: echo "NIXPKGS_COMMIT=$(curl -L 'https://channels.nixos.org/nixos-unstable/git-revision')" >> $GITHUB_ENV
       - name: Install Nix


### PR DESCRIPTION
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/